### PR TITLE
Update Jack Luo website copyright and bio

### DIFF
--- a/website/public/index.html
+++ b/website/public/index.html
@@ -112,7 +112,7 @@
 
             <div class="row landing-row">
               <h3>
-                Currently: Building @ Mira and ASJ Trading
+                Currently: Building @ <a href="https://magk.app">MAGK</a>
               </h3>
             </div>
             <div class="row landing-row">
@@ -196,13 +196,16 @@
                           </li>
                           <li>
                             Building
-                            <a class="a-underline" href="https://github.com/magic-m-app/the-light"
-                              >the light</a
+                            <a class="a-underline" href="https://github.com/magk-app/delight"
+                              >delight</a
                             >
                             to create next generation productivity software
                           </li>
                           <li>
-                            Interested in creating better memory architectures, context engineering, and tool use in single and multi-agent systems, especially in the context of personal assistance in work and life
+                            Interested in creating better <a class="a-underline" href="https://medium.com/@thejackluo8/hierarchical-memory-and-adaptive-state-management-for-an-ai-agent-f99a50562837">memory architectures</a>, context engineering, and tool use in single and multi-agent systems, especially in the context of personal assistance in work and life
+                          </li>
+                          <li>
+                            Writing blogs on <a class="a-underline" href="https://medium.com/@thejackluo8">Medium</a> (just surpassed 50 blogs!)
                           </li>
                           <li>
                             Pursuing an
@@ -244,15 +247,15 @@
                               >here</
                             >
                           </li>
-                          <li>Coorganized <b><a class="a-underline" href="assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2024, and helped inspire the vision for Georgia Tech Hacker House 2025</li>
+                          <li>Coorganized <b><a class="a-underline" href="assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2025, and helped inspire the vision for Georgia Tech Hacker House 2025. Slept on <a class="a-underline" href="assets/index/roof.jpg">roof</a></li>
                           <li>
-                            Currently working on agentic architecture at <b>MIT SIPB Arc Project</b>
+                            Currently working on agentic architecture at <b><a class="a-underline" href="https://github.com/SGIARK/arkos">MIT SIPB Arc Project</a></b>
                           </li>
                           <li>
                             Attended <b>NVIDIA conference</b>, hosting a group to <b>CES</b> (contact me if interested!), and slept in a <b>WeWork office for a month</b>
                           </li>
                           <li>
-                            Growth hacked 30X in <a class="a-underline" href="https://deso.com"></a> through ETH
+                            Growth hacked 30X in <a class="a-underline" href="https://www.deso.com/">Deso</a> through ETH
                             and alt coins
                           </li>
                           <li>

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -244,8 +244,9 @@
                             <a
                               class="a-underline"
                               href="https://youtu.be/x0ZoUqVQp7l"
-                              >here</
-                            >
+                              >here</a
+                            >.
+                            Featured in <a class="a-underline" href="https://towardsai.net/p/news/elon-musk-on-hack-clubs-high-school-student-members">Towards AI news</a>
                           </li>
                           <li>Coorganized <b><a class="a-underline" href="assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2025, and helped inspire the vision for Georgia Tech Hacker House 2025. Slept on <a class="a-underline" href="assets/index/roof.jpg">roof</a></li>
                           <li>

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -192,22 +192,17 @@
                         <p><b>Currently:</b></p>
                         <ul>
                           <li>
-                            I am a third year student for
-                            <b>Computer Science</b> and
-                            <b>Mathematics</b>
+                            I am a fourth year student in computer science focused on artificial intelligence and robotics
                           </li>
                           <li>
                             Building
-                            <a class="a-underline" href="https://vigama.tech/"
-                              >Vigama</a
+                            <a class="a-underline" href="https://github.com/magic-m-app/the-light"
+                              >the light</a
                             >
-                            and <a>Calend.ai (coming soon)</a> to create next
-                            gen <b>automated</b> productivity
+                            to create next generation productivity software
                           </li>
                           <li>
-                            <b>Learning</b> about advanced NLP architectures to
-                            support the future of AI personal Assistants in work
-                            and personal life
+                            Interested in creating better memory architectures, context engineering, and tool use in single and multi-agent systems, especially in the context of personal assistance in work and life
                           </li>
                           <li>
                             Pursuing an
@@ -215,7 +210,7 @@
                               >unconventional education</a
                             >
                             through <b>Building sh*t</b> and
-                            <b>Tackling Challenges</b>
+                            <b>Tackling Challenges</b>. Very spontaneous and love taking on new challenges - reach out if you're interested in collaborating!
                           </li>
                           <li>
                             Explore my collection of books and reading progress. Click <a class="a-underline" href="special/books.html">here</a> to dive into my bookshelf.
@@ -227,6 +222,9 @@
                       <div class="about-row">
                         <p><b>Previously:</b></p>
                         <ul>
+                          <li>
+                            <b>Won finalist</b> @ Penn's pitch app pitch competition and Northwestern's pitch competition
+                          </li>
                           <li>
                             <b>Won</b> <a class="a-underline"
                             href="https://www.linkedin.com/feed/update/urn:li:activity:7215992989540626432/">Top 15</a> @ Berkeley AI Hackathon and <b>1st place</b> @ Digitalized & CodeDay SF
@@ -246,9 +244,13 @@
                               >here</
                             >
                           </li>
-                          <li>Coorganized <b><a class="a-underline" href="assets/index/qhouse.jpg">Q House</a></b> with 10 full time + guests. Slept on <a class="a-underline" href="assets/index/roof.jpg">roof</a></li>
-                         
-                          
+                          <li>Coorganized <b><a class="a-underline" href="assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2024, and helped inspire the vision for Georgia Tech Hacker House 2025</li>
+                          <li>
+                            Currently working on agentic architecture at <b>MIT SIPB Arc Project</b>
+                          </li>
+                          <li>
+                            Attended <b>NVIDIA conference</b>, hosting a group to <b>CES</b> (contact me if interested!), and slept in a <b>WeWork office for a month</b>
+                          </li>
                           <li>
                             Growth hacked 30X in <a class="a-underline" href="https://deso.com"></a> through ETH
                             and alt coins
@@ -291,10 +293,9 @@
                   </div>
                   <div class="row about-row about-interests">
                     <p>
-                      Outside of work, I enjoy riding my electric unicycle to
-                      explore the world, immeresing myself to the Japanese
-                      language, and reading great stories of humans in this
-                      world. My goal in this world is to find fulfillment and
+                      Outside of work, I love traveling and have been to almost all major U.S. cities. I enjoy riding my electric unicycle to
+                      explore the world, currently learning Japanese (somewhere between N3 and N4 level), and reading great stories of humans in this
+                      world. Currently reading <b>Understanding Deep Learning</b>. My goal in this world is to find fulfillment and
                       seek all experiences, and help others do the same. If you
                       want to connect with me, feel free to
                       <a class="a-underline" href="mailto:jack@hexahacks.com"
@@ -380,7 +381,7 @@
             </div>
           </div>
           <div class="row footer-copyright">
-            <div class="row"><h5>2024 All rights reserved</h5></div>
+            <div class="row"><h5>2025 All rights reserved</h5></div>
             <div class="row">
               <h4>
                 Designed & Built by

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div class="row footer-copyright">
-      <div class="row"><h5>2024 All rights reserved</h5></div>
+      <div class="row"><h5>2025 All rights reserved</h5></div>
       <div class="row">
         <h4>
           Designed &amp; Built by

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -136,7 +136,8 @@ import BaseLayout from '../layouts/Base.astro';
                         Discussed AI and future w/ <b>Elon Musk</b> on video calls
                         <a class="a-underline" href="https://youtu.be/aVvZniTjHtM">here</a>
                         and
-                        <a class="a-underline" href="https://youtu.be/x0ZoUqVQp7l">here</a>
+                        <a class="a-underline" href="https://youtu.be/x0ZoUqVQp7l">here</a>.
+                        Featured in <a class="a-underline" href="https://towardsai.net/p/news/elon-musk-on-hack-clubs-high-school-student-members">Towards AI news</a>
                       </li>
                       <li>
                         Coorganized <b><a class="a-underline" href="/assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2025, and helped inspire the vision for Georgia Tech Hacker House 2025. Slept on <a class="a-underline" href="/assets/index/roof.jpg">roof</a>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -24,7 +24,7 @@ import BaseLayout from '../layouts/Base.astro';
     </div>
 
     <div class="row landing-row">
-      <h3>Currently: Building @ Mira and ASJ Trading</h3>
+      <h3>Currently: Building @ <a href="https://magk.app">MAGK</a></h3>
     </div>
     <div class="row landing-row">
       <a href="#about" aria-label="Scroll to about section">
@@ -90,23 +90,23 @@ import BaseLayout from '../layouts/Base.astro';
                     <p><b>Currently:</b></p>
                     <ul>
                       <li>
-                        I am a third year student for <b>Computer Science</b> and
-                        <b>Mathematics</b>
+                        I am a fourth year student in computer science focused on artificial intelligence and robotics
                       </li>
                       <li>
                         Building
-                        <a class="a-underline" href="https://vigama.tech/">Vigama</a>
-                        and <a>Calend.ai (coming soon)</a> to create next gen
-                        <b>automated</b> productivity
+                        <a class="a-underline" href="https://github.com/magk-app/delight">delight</a>
+                        to create next generation productivity software
                       </li>
                       <li>
-                        <b>Learning</b> about advanced NLP architectures to support
-                        the future of AI personal Assistants in work and personal life
+                        Interested in creating better <a class="a-underline" href="https://medium.com/@thejackluo8/hierarchical-memory-and-adaptive-state-management-for-an-ai-agent-f99a50562837">memory architectures</a>, context engineering, and tool use in single and multi-agent systems, especially in the context of personal assistance in work and life
+                      </li>
+                      <li>
+                        Writing blogs on <a class="a-underline" href="https://medium.com/@thejackluo8">Medium</a> (just surpassed 50 blogs!)
                       </li>
                       <li>
                         Pursuing an
                         <a class="a-underline" href="/blogs/mit.html">unconventional education</a>
-                        through <b>Building sh*t</b> and <b>Tackling Challenges</b>
+                        through <b>Building sh*t</b> and <b>Tackling Challenges</b>. Very spontaneous and love taking on new challenges - reach out if you're interested in collaborating!
                       </li>
                       <li>
                         Explore my collection of books and reading progress. Click
@@ -119,6 +119,9 @@ import BaseLayout from '../layouts/Base.astro';
                   <div class="about-row">
                     <p><b>Previously:</b></p>
                     <ul>
+                      <li>
+                        <b>Won finalist</b> @ Penn's pitch app pitch competition and Northwestern's pitch competition
+                      </li>
                       <li>
                         <b>Won</b>
                         <a
@@ -136,13 +139,17 @@ import BaseLayout from '../layouts/Base.astro';
                         <a class="a-underline" href="https://youtu.be/x0ZoUqVQp7l">here</a>
                       </li>
                       <li>
-                        Coorganized <b><a class="a-underline" href="/assets/index/qhouse.jpg">Q House</a></b>
-                        with 10 full time + guests. Slept on
-                        <a class="a-underline" href="/assets/index/roof.jpg">roof</a>
+                        Coorganized <b><a class="a-underline" href="/assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2025, and helped inspire the vision for Georgia Tech Hacker House 2025. Slept on <a class="a-underline" href="/assets/index/roof.jpg">roof</a>
+                      </li>
+                      <li>
+                        Currently working on agentic architecture at <b><a class="a-underline" href="https://github.com/SGIARK/arkos">MIT SIPB Arc Project</a></b>
+                      </li>
+                      <li>
+                        Attended <b>NVIDIA conference</b>, hosting a group to <b>CES</b> (contact me if interested!), and slept in a <b>WeWork office for a month</b>
                       </li>
                       <li>
                         Growth hacked 30X in
-                        <a class="a-underline" href="https://deso.com">Deso</a> through ETH and alt coins
+                        <a class="a-underline" href="https://www.deso.com/">Deso</a> through ETH and alt coins
                       </li>
                       <li>
                         Graduated from
@@ -168,9 +175,9 @@ import BaseLayout from '../layouts/Base.astro';
               </div>
               <div class="row about-row about-interests">
                 <p>
-                  Outside of work, I enjoy riding my electric unicycle to explore the world,
-                  immeresing myself to the Japanese language, and reading great stories of
-                  humans in this world. My goal in this world is to find fulfillment and seek
+                  Outside of work, I love traveling and have been to almost all major U.S. cities. I enjoy riding my electric unicycle to
+                  explore the world, currently learning Japanese (somewhere between N3 and N4 level), and reading great stories of humans in this
+                  world. Currently reading <b>Understanding Deep Learning</b>. My goal in this world is to find fulfillment and seek
                   all experiences, and help others do the same. If you want to connect with
                   me, feel free to
                   <a class="a-underline" href="mailto:jack@hexahacks.com">shoot me a message</a>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refreshes homepage bio, achievements, and interests (including MAGK and new links) and updates copyright to 2025.
> 
> - **Homepage content updates**:
>   - `website/public/index.html`, `website/src/pages/index.astro`:
>     - Landing tagline: change to “Currently: Building @ `MAGK`” with link.
>     - About — *Currently*: update student status (4th year, AI/robotics), project to `magk-app/delight`, add interests (memory architectures, context/tool use), Medium blogging, and collaboration note.
>     - About — *Previously*: add finalist wins (Penn, Northwestern), media feature (Towards AI), hacker houses (Q House, NY, GT), MIT SIPB Arc work, events (NVIDIA, CES, WeWork), and fix `Deso` link; minor punctuation tweaks.
>     - Interests paragraph: expand travel/Japanese details and current reading (Understanding Deep Learning).
> - **Footer**:
>   - Update copyright year to `2025` in `website/public/index.html` and `website/src/components/Footer.astro`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a067b23a2b34f22b4faed04f97bcbae6e00bb94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->