### PR TITLE
Update website: identity, press section, projects, and Previously reo…

### DIFF
--- a/website/public/journey.html
+++ b/website/public/journey.html
@@ -77,6 +77,9 @@
                 <div class="nav-item">
                   <a href="writing.html"><h2>Writing</h2></a>
                 </div>
+                <div class="nav-item">
+                  <a href="/press"><h2>Press</h2></a>
+                </div>
               </div>
             </div>
           </nav>
@@ -100,6 +103,37 @@
                 playlist.
               </p> -->
               <h3>Projects</h3>
+              <p><i>Delight is the long-term vision; Weaive is the first shipped product.</i></p>
+              <div class="row">
+                <div class="col-sm-12 col-md-6 col-4-lg">
+                  <div class="project-card">
+                    <h3 class="project-header"><a href="https://agentschool.io" class="a-underline">Agent School</a> - AI automation platform</h3>
+                    <p>
+                      A platform for certified, test-driven AI automations that work reliably in messy real-world software.
+                    </p>
+                    <ul>
+                      <li>Deterministic, observable workflows with logging and evals built in</li>
+                      <li>Robust to UI changes - automations don't break when software updates</li>
+                      <li>Cost-controlled execution with reliability guarantees for legacy workflows</li>
+                      <li>Targets workflows that are fast, cheap, and auditable</li>
+                    </ul>
+                  </div>
+                </div>
+                <div class="col-sm-12 col-md-6 col-4-lg">
+                  <div class="project-card">
+                    <h3 class="project-header"><a href="https://weaive.app" class="a-underline">Weaive</a> - Personal growth app (alpha)</h3>
+                    <p>
+                      A lightweight personal growth and reflection app focused on consistency and clarity.
+                    </p>
+                    <ul>
+                      <li>Combines reflection, action tracking, and progress visibility in one minimal interface</li>
+                      <li>Built for individuals who want to build habits and track growth without overhead</li>
+                      <li>Currently in alpha - core reflection and tracking flows are live</li>
+                      <li>Next: social accountability features and longer-term progress analytics</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
               <div class="row">
                 <div class="col-sm-12 col-md-6 col-4-lg">
                   <div class="project-card">

--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -3,6 +3,7 @@ const { currentPage = 'home' } = Astro.props;
 const navLinks = [
   { href: '/journey.html', label: 'Journey' },
   { href: '/writing', label: 'Writing' },
+  { href: '/press', label: 'Press' },
 ];
 ---
 <section id="landing">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -24,7 +24,7 @@ import BaseLayout from '../layouts/Base.astro';
     </div>
 
     <div class="row landing-row">
-      <h3>Currently: Building @ <a href="https://magk.app">MAGK</a></h3>
+      <h3>Founder building full-time (previously Georgia Tech CS)</h3>
     </div>
     <div class="row landing-row">
       <a href="#about" aria-label="Scroll to about section">
@@ -90,27 +90,31 @@ import BaseLayout from '../layouts/Base.astro';
                     <p><b>Currently:</b></p>
                     <ul>
                       <li>
-                        I am a fourth year student in computer science focused on artificial intelligence and robotics
+                        Founder building <a class="a-underline" href="https://agentschool.io">Agent School</a>: certified, test-driven AI automations for legacy workflows (fast, cheap, observable, robust to UI changes).
                       </li>
                       <li>
-                        Building
-                        <a class="a-underline" href="https://github.com/magk-app/delight">delight</a>
-                        to create next generation productivity software
+                        Shipped <a class="a-underline" href="https://weaive.app">Weaive</a> (alpha): a minimal personal growth system for reflection, action, and progress tracking.
                       </li>
                       <li>
-                        Interested in creating better <a class="a-underline" href="https://medium.com/@thejackluo8/hierarchical-memory-and-adaptive-state-management-for-an-ai-agent-f99a50562837">memory architectures</a>, context engineering, and tool use in single and multi-agent systems, especially in the context of personal assistance in work and life
+                        Focus: memory architectures, context engineering, tool use, evals, and multi-agent reliability with cost control and deterministic workflows.
                       </li>
                       <li>
-                        Writing blogs on <a class="a-underline" href="https://medium.com/@thejackluo8">Medium</a> (just surpassed 50 blogs!)
+                        Writing: 50+ posts on <a class="a-underline" href="https://medium.com/@thejackluo8">Medium</a> (AI, builders, systems, life).
+                      </li>
+                    </ul>
+                  </div>
+
+                  <div class="about-row">
+                    <p><b>Press:</b></p>
+                    <ul>
+                      <li>
+                        Featured in AFP-syndicated coverage on AI agent autonomy, consent, and safety.
                       </li>
                       <li>
-                        Pursuing an
-                        <a class="a-underline" href="/blogs/mit.html">unconventional education</a>
-                        through <b>Building sh*t</b> and <b>Tackling Challenges</b>. Very spontaneous and love taking on new challenges - reach out if you're interested in collaborating!
+                        <a class="a-underline" href="https://www.straitstimes.com/asia/east-asia/when-machines-do-the-flirting-ai-agents-create-surprise-dating-accounts-for-humans">The Straits Times</a> (2026-02-13)
                       </li>
                       <li>
-                        Explore my collection of books and reading progress. Click
-                        <a class="a-underline" href="/special/books.html">here</a> to dive into my bookshelf.
+                        <a class="a-underline" href="https://m.economictimes.com/tech/artificial-intelligence/hot-bots-ai-agents-create-surprise-dating-accounts-for-humans/articleshow/128286633.cms">The Economic Times</a> (2026-02-13)
                       </li>
                     </ul>
                   </div>
@@ -118,10 +122,24 @@ import BaseLayout from '../layouts/Base.astro';
                 <div class="col-md-6 col-sm-12">
                   <div class="about-row">
                     <p><b>Previously:</b></p>
+
+                    <p><i>Build</i></p>
                     <ul>
                       <li>
-                        <b>Won finalist</b> @ Penn's pitch app pitch competition and Northwestern's pitch competition
+                        Excel workflow automations for an Asia-based equity research firm
                       </li>
+                      <li>
+                        Agentic architecture work at <b><a class="a-underline" href="https://github.com/SGIARK/arkos">MIT SIPB Arc Project</a></b>
+                      </li>
+                      <li>
+                        Graduated from
+                        <a class="a-underline" href="https://buildspace.so/">Buildspace</a>
+                        nights and weekends S4
+                      </li>
+                    </ul>
+
+                    <p><i>Credibility</i></p>
+                    <ul>
                       <li>
                         <b>Won</b>
                         <a
@@ -133,29 +151,13 @@ import BaseLayout from '../layouts/Base.astro';
                         @ Berkeley AI Hackathon and <b>1st place</b> @ Digitalized &amp; CodeDay SF
                       </li>
                       <li>
-                        Discussed AI and future w/ <b>Elon Musk</b> on video calls
+                        <b>Won finalist</b> @ Penn's pitch competition and Northwestern's pitch competition
+                      </li>
+                      <li>
+                        Discussed AI with <b>Elon Musk</b> on video calls
                         <a class="a-underline" href="https://youtu.be/aVvZniTjHtM">here</a>
                         and
-                        <a class="a-underline" href="https://youtu.be/x0ZoUqVQp7l">here</a>.
-                        Featured in <a class="a-underline" href="https://towardsai.net/p/news/elon-musk-on-hack-clubs-high-school-student-members">Towards AI news</a>
-                      </li>
-                      <li>
-                        Coorganized <b><a class="a-underline" href="/assets/index/qhouse.jpg">Q House</a></b> 2023, New York Hacker House 2025, and helped inspire the vision for Georgia Tech Hacker House 2025. Slept on <a class="a-underline" href="/assets/index/roof.jpg">roof</a>
-                      </li>
-                      <li>
-                        Currently working on agentic architecture at <b><a class="a-underline" href="https://github.com/SGIARK/arkos">MIT SIPB Arc Project</a></b>
-                      </li>
-                      <li>
-                        Attended <b>NVIDIA conference</b>, hosting a group to <b>CES</b> (contact me if interested!), and slept in a <b>WeWork office for a month</b>
-                      </li>
-                      <li>
-                        Growth hacked 30X in
-                        <a class="a-underline" href="https://www.deso.com/">Deso</a> through ETH and alt coins
-                      </li>
-                      <li>
-                        Graduated from
-                        <a class="a-underline" href="https://buildspace.so/">nights and weekends</a>
-                        S4
+                        <a class="a-underline" href="https://youtu.be/x0ZoUqVQp7l">here</a> - featured in <a class="a-underline" href="https://towardsai.net/p/news/elon-musk-on-hack-clubs-high-school-student-members">Towards AI</a>
                       </li>
                       <li>
                         Got <b>viral</b> on TikTok totaling <b>2 million+ views</b>
@@ -164,11 +166,24 @@ import BaseLayout from '../layouts/Base.astro';
                         <a class="a-underline" href="https://www.tiktok.com/@chrisclipsss/video/7151459400887274798">here</a>
                       </li>
                       <li>
-                        Researched about neural networks architecture in natural language processing
+                        Researched neural networks architecture in natural language processing
+                      </li>
+                    </ul>
+
+                    <p><i>Community</i></p>
+                    <ul>
+                      <li>
+                        Co-organized <b><a class="a-underline" href="/assets/index/qhouse.jpg">Q House</a></b>, a builder hacker house (2023), and New York Hacker House (2025)
                       </li>
                       <li>
-                        Explore projects I've worked on in detail in
-                        <a class="a-underline" href="/journey.html">Journeys</a>
+                        Attended <b>NVIDIA conference</b> and hosted a CES delegation (user-claimed)
+                      </li>
+                    </ul>
+
+                    <p><i>Fun</i></p>
+                    <ul>
+                      <li>
+                        Slept on a <a class="a-underline" href="/assets/index/roof.jpg">rooftop</a> and in a WeWork office for a month
                       </li>
                     </ul>
                   </div>

--- a/website/src/pages/press.astro
+++ b/website/src/pages/press.astro
@@ -1,0 +1,64 @@
+---
+import BaseLayout from '../layouts/Base.astro';
+---
+<BaseLayout currentPage="press">
+  <div slot="hero" class="landing-main container-fluid">
+    <div class="row landing-row">
+      <h2>Press</h2>
+    </div>
+  </div>
+
+  <section id="about">
+    <div class="container-fluid">
+      <div class="row">
+        <div class="col-1"></div>
+        <div class="col-10">
+          <div class="about-main container-fluid">
+            <div class="about-main-text-body">
+
+              <div class="row">
+                <div class="col-sm-12">
+                  <div class="about-row">
+                    <p>
+                      In February 2026, Jack was featured in AFP-syndicated coverage examining questions around
+                      AI agent autonomy, consent, and safety. The story explored scenarios where AI agents
+                      take unsanctioned actions on behalf of users, raising practical questions about trust,
+                      authorization, and evaluation in agentic systems. This intersects directly with ongoing
+                      work on Agent School: building reliable, test-driven, and observable AI automations.
+                    </p>
+                  </div>
+
+                  <div class="about-row">
+                    <p><b>Coverage:</b></p>
+                    <ul>
+                      <li>
+                        <a class="a-underline" href="https://www.straitstimes.com/asia/east-asia/when-machines-do-the-flirting-ai-agents-create-surprise-dating-accounts-for-humans">The Straits Times</a> - "When machines do the flirting: AI agents create surprise dating accounts for humans" (2026-02-13)
+                      </li>
+                      <li>
+                        <a class="a-underline" href="https://m.economictimes.com/tech/artificial-intelligence/hot-bots-ai-agents-create-surprise-dating-accounts-for-humans/articleshow/128286633.cms">The Economic Times</a> - "Hot bots: AI agents create surprise dating accounts for humans" (2026-02-13)
+                      </li>
+                    </ul>
+                  </div>
+
+                  <div class="about-row">
+                    <p><b>Related work:</b></p>
+                    <ul>
+                      <li>
+                        <a class="a-underline" href="https://agentschool.io">Agent School</a> - certified, test-driven AI automations for legacy workflows (fast, cheap, observable, robust to UI changes)
+                      </li>
+                      <li>
+                        <a class="a-underline" href="https://weaive.app">Weaive</a> - a lightweight personal growth and reflection app focused on consistency and clarity
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+        </div>
+        <div class="col-1"></div>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
…rganization

- index.astro: Replace "fourth year student at Georgia Tech" hero text with "Founder building full-time (previously Georgia Tech CS)". Rewrite Currently section with Agent School and Weaive as top items. Add Press section below Currently with AFP-syndicated coverage links. Reorganize Previously into grouped categories: Build, Credibility, Community, Fun.
- Header.astro: Add Press nav link to all Astro-rendered pages.
- press.astro: New /press page with context on AI agent autonomy coverage, links to The Straits Times and The Economic Times, and related work section.
- journey.html: Add Press nav link. Add Agent School and Weaive as headline project cards above existing projects. Add Delight vs Weaive clarification.

https://claude.ai/code/session_01K34w4DhQF1gwvGTXXXhQ6M

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only changes to static/Astro pages (navigation and copy) with no backend logic or data handling changes.
> 
> **Overview**
> Adds a new `press.astro` page and a `Press` nav link (in both the Astro header and the static `journey.html`) to expose AFP-syndicated coverage links and related work.
> 
> Updates `index.astro` copy to reflect a founder-focused identity, adds an inline Press section with coverage links, and reorganizes the “Previously” content into grouped categories. Updates `journey.html` to feature new headline project cards for Agent School and Weaive plus a short Delight/Weaive positioning note above existing projects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a836cd6870abd1fd60dcdbfde0e024ad6016cd3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->